### PR TITLE
修复客户端断联异常bug

### DIFF
--- a/Server/server/server.cpp
+++ b/Server/server/server.cpp
@@ -214,7 +214,7 @@ DWORD __stdcall cleanThread(void* pParam)
 			CClient *pClient = (CClient*)*iter;
 			if (!pClient->IsConning())			//客户端线程已经退出
 			{
-				clientvector.erase(iter);	//删除节点
+				iter = clientvector.erase(iter);	//删除节点
 				delete pClient;				//释放内存
 				pClient = NULL;
 			}else{


### PR DESCRIPTION
客户端主动断联时，会触发服务器崩溃。
原因是清理客户端vector时erase函数调用后引发原迭代器iter失效。